### PR TITLE
Add custom theme with OKLCH color format

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "../styles/custom-theme.css";
 
 /* Font definitions */
 @font-face {

--- a/src/styles/custom-theme.css
+++ b/src/styles/custom-theme.css
@@ -1,0 +1,79 @@
+@layer base {
+  :root {
+    --radius: 0.5rem;
+    
+    /* Light theme - converted from HSL to OKLCH */
+    --background: oklch(1 0 0);                /* hsl(0 0% 100%) */
+    --foreground: oklch(0.141 0.005 285.823);  /* hsl(240 10% 3.9%) */
+    
+    --card: oklch(1 0 0);                      /* hsl(0 0% 100%) */
+    --card-foreground: oklch(0.141 0.005 285.823); /* hsl(240 10% 3.9%) */
+    
+    --popover: oklch(1 0 0);                   /* hsl(0 0% 100%) */
+    --popover-foreground: oklch(0.141 0.005 285.823); /* hsl(240 10% 3.9%) */
+    
+    --primary: oklch(0.21 0.006 285.885);      /* hsl(240 5.9% 10%) */
+    --primary-foreground: oklch(0.985 0 0);    /* hsl(0 0% 98%) */
+    
+    --secondary: oklch(0.967 0.001 286.375);   /* hsl(240 4.8% 95.9%) */
+    --secondary-foreground: oklch(0.21 0.006 285.885); /* hsl(240 5.9% 10%) */
+    
+    --muted: oklch(0.967 0.001 286.375);       /* hsl(240 4.8% 95.9%) */
+    --muted-foreground: oklch(0.552 0.016 285.938); /* hsl(240 3.8% 46.1%) */
+    
+    --accent: oklch(0.967 0.001 286.375);      /* hsl(240 4.8% 95.9%) */
+    --accent-foreground: oklch(0.21 0.006 285.885); /* hsl(240 5.9% 10%) */
+    
+    --destructive: oklch(0.577 0.245 27.325);  /* hsl(0 84.2% 60.2%) */
+    --destructive-foreground: oklch(0.985 0 0); /* hsl(0 0% 98%) */
+    
+    --border: oklch(0.92 0.004 286.32);        /* hsl(240 5.9% 90%) */
+    --input: oklch(0.92 0.004 286.32);         /* hsl(240 5.9% 90%) */
+    --ring: oklch(0.21 0.006 285.885);         /* hsl(240 5.9% 10%) */
+    
+    /* Chart colors */
+    --chart-1: oklch(0.646 0.222 41.116);      /* hsl(12 76% 61%) */
+    --chart-2: oklch(0.6 0.118 184.704);       /* hsl(173 58% 39%) */
+    --chart-3: oklch(0.398 0.07 227.392);      /* hsl(197 37% 24%) */
+    --chart-4: oklch(0.828 0.189 84.429);      /* hsl(43 74% 66%) */
+    --chart-5: oklch(0.769 0.188 70.08);       /* hsl(27 87% 67%) */
+  }
+
+  .dark {
+    /* Dark theme - converted from HSL to OKLCH */
+    --background: oklch(0.141 0.005 285.823);  /* hsl(240 10% 3.9%) */
+    --foreground: oklch(0.985 0 0);            /* hsl(0 0% 98%) */
+    
+    --card: oklch(0.141 0.005 285.823);        /* hsl(240 10% 3.9%) */
+    --card-foreground: oklch(0.985 0 0);       /* hsl(0 0% 98%) */
+    
+    --popover: oklch(0.141 0.005 285.823);     /* hsl(240 10% 3.9%) */
+    --popover-foreground: oklch(0.985 0 0);    /* hsl(0 0% 98%) */
+    
+    --primary: oklch(0.985 0 0);               /* hsl(0 0% 98%) */
+    --primary-foreground: oklch(0.21 0.006 285.885); /* hsl(240 5.9% 10%) */
+    
+    --secondary: oklch(0.274 0.006 286.033);   /* hsl(240 3.7% 15.9%) */
+    --secondary-foreground: oklch(0.985 0 0);  /* hsl(0 0% 98%) */
+    
+    --muted: oklch(0.274 0.006 286.033);       /* hsl(240 3.7% 15.9%) */
+    --muted-foreground: oklch(0.705 0.015 286.067); /* hsl(240 5% 64.9%) */
+    
+    --accent: oklch(0.274 0.006 286.033);      /* hsl(240 3.7% 15.9%) */
+    --accent-foreground: oklch(0.985 0 0);     /* hsl(0 0% 98%) */
+    
+    --destructive: oklch(0.38 0.16 22);        /* hsl(0 62.8% 30.6%) */
+    --destructive-foreground: oklch(0.985 0 0); /* hsl(0 0% 98%) */
+    
+    --border: oklch(0.274 0.006 286.033);      /* hsl(240 3.7% 15.9%) */
+    --input: oklch(0.274 0.006 286.033);       /* hsl(240 3.7% 15.9%) */
+    --ring: oklch(0.88 0.02 285);              /* hsl(240 4.9% 83.9%) */
+    
+    /* Chart colors */
+    --chart-1: oklch(0.55 0.18 260);           /* hsl(220 70% 50%) */
+    --chart-2: oklch(0.65 0.15 160);           /* hsl(160 60% 45%) */
+    --chart-3: oklch(0.7 0.2 30);              /* hsl(30 80% 55%) */
+    --chart-4: oklch(0.6 0.2 280);             /* hsl(280 65% 60%) */
+    --chart-5: oklch(0.65 0.22 340);           /* hsl(340 75% 55%) */
+  }
+}


### PR DESCRIPTION
This pull request introduces a custom theme to the project by adding new CSS variables and importing the custom theme file into the global styles. The most important changes include the addition of the custom theme CSS file and the definition of color variables for both light and dark themes using the OKLCH color model.

Theme enhancements:

* [`src/app/globals.css`](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R3): Imported the new custom theme CSS file to apply the custom styles globally.
* [`src/styles/custom-theme.css`](diffhunk://#diff-1090e2a31038447ff2b40c6a75e49d9ab3ee499a491613bc98dd33aec68c9aebR1-R79): Added a new CSS file defining a custom theme with color variables for light and dark modes using the OKLCH color model. This includes variables for background, foreground, card, popover, primary, secondary, muted, accent, destructive, border, input, ring, and chart colors.